### PR TITLE
Added null coalescing assignment operator for the base resource

### DIFF
--- a/src/OData/BaseResource.php
+++ b/src/OData/BaseResource.php
@@ -28,8 +28,8 @@ abstract class BaseResource implements ArrayAccess, Arrayable
 
     public function __construct(?string $connection = null, ?string $endpoint = null)
     {
-        $this->connection = $connection ?? config('dynamics.connection');
-        $this->endpoint = $endpoint ?? config('dynamics.resources.'.static::class, Str::afterLast(static::class, '\\'));
+        $this->connection ??= $connection ?? config('dynamics.connection');
+        $this->endpoint ??= $endpoint ?? config('dynamics.resources.'.static::class, Str::afterLast(static::class, '\\'));
     }
 
     public static function new(?string $connection = null, ?string $endpoint = null): static

--- a/tests/Fakes/OData/FakeResource.php
+++ b/tests/Fakes/OData/FakeResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JustBetter\DynamicsClient\Tests\Fakes\OData;
+
+use JustBetter\DynamicsClient\OData\BaseResource;
+
+class FakeResource extends BaseResource
+{
+    public string $connection = '::fake-connection::';
+
+    public string $endpoint = '::fake-endpoint::';
+
+    public array $primaryKey = [
+        'No',
+    ];
+}

--- a/tests/OData/BaseResourceTest.php
+++ b/tests/OData/BaseResourceTest.php
@@ -3,6 +3,7 @@
 namespace JustBetter\DynamicsClient\Tests\OData;
 
 use JustBetter\DynamicsClient\OData\Pages\Customer;
+use JustBetter\DynamicsClient\Tests\Fakes\OData\FakeResource;
 use JustBetter\DynamicsClient\Tests\TestCase;
 
 class BaseResourceTest extends TestCase
@@ -10,6 +11,10 @@ class BaseResourceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        config()->set('dynamics.resources', [
+            Customer::class => '::customer-endpoint::',
+        ]);
 
         config()->set('dynamics.connections.::default::', [
             'base_url' => '::base_url::',
@@ -45,6 +50,14 @@ class BaseResourceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_default_endpoint(): void
+    {
+        $page = new Customer();
+
+        $this->assertEquals('::customer-endpoint::', $page->endpoint);
+    }
+
+    /** @test */
     public function it_can_set_the_connection(): void
     {
         $page = new Customer('::other-connection::');
@@ -54,5 +67,26 @@ class BaseResourceTest extends TestCase
         $page = Customer::new('::other-connection::');
 
         $this->assertEquals('::other-connection::', $page->connection);
+    }
+
+    /** @test */
+    public function it_can_set_the_endpoint(): void
+    {
+        $page = new Customer(null, '::other-endpoint::');
+
+        $this->assertEquals('::other-endpoint::', $page->endpoint);
+
+        $page = Customer::new(null, '::other-endpoint::');
+
+        $this->assertEquals('::other-endpoint::', $page->endpoint);
+    }
+
+    /** @test */
+    public function it_can_force_a_connection_and_endpoint(): void
+    {
+        $resource = FakeResource::new();
+
+        $this->assertEquals('::fake-connection::', $resource->connection);
+        $this->assertEquals('::fake-endpoint::', $resource->endpoint);
     }
 }


### PR DESCRIPTION
Adding a null coalescing assignment operator for the base resource will allow resources to force a default `connection` and `endpoint` without configuration.