### PR TITLE
Implemented date cast when using the find method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "justbetter/odata-client": "^1.0",
+        "justbetter/odata-client": "^1.1",
         "laravel/framework": "^9.0"
     },
     "require-dev": {

--- a/src/Concerns/HasCasts.php
+++ b/src/Concerns/HasCasts.php
@@ -6,9 +6,14 @@ trait HasCasts
 {
     public array $casts = [];
 
+    public function getCastType(string $key): ?string
+    {
+        return $this->casts[$key] ?? null;
+    }
+
     public function cast(string $key, mixed $value): string
     {
-        return match ($this->casts[$key] ?? null) {
+        return match ($this->getCastType($key)) {
             'int', 'date', 'decimal' => (string) $value,
             default => '\''.$value.'\'',
         };

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -79,8 +79,18 @@ class QueryBuilder
         /** @var BaseResource $baseResource */
         $baseResource = app($class);
 
+        $combined = array_combine($baseResource->primaryKey, $values);
+
+        foreach ($combined as $key => $value) {
+            if ($baseResource->getCastType($key) === 'date') {
+                $this->builder->whereDate($key, '=', $value);
+            } else {
+                $this->builder->where($key, '=', $value);
+            }
+        }
+
         /** @var ?Entity $entity */
-        $entity = $this->builder->where(array_combine($baseResource->primaryKey, $values))->first();
+        $entity = $this->builder->first();
 
         return is_null($entity)
             ? null


### PR DESCRIPTION
When using the `find` method it will now use the method `whereDate` to prevent comparing the date as a string.