### PR TITLE
Allow overriding the ClientFactory to support alternative Authentification methods (such as OAuth)

### DIFF
--- a/src/Client/ClientFactory.php
+++ b/src/Client/ClientFactory.php
@@ -2,11 +2,12 @@
 
 namespace JustBetter\DynamicsClient\Client;
 
-use JustBetter\DynamicsClient\Exceptions\DynamicsException;
 use SaintSystems\OData\ODataClient;
+use JustBetter\DynamicsClient\Exceptions\DynamicsException;
+use JustBetter\DynamicsClient\Contracts\ClientFactoryContract;
 
 /** @phpstan-consistent-constructor */
-class ClientFactory
+class ClientFactory implements ClientFactoryContract
 {
     public array $options = [];
 

--- a/src/Contracts/ClientFactoryContract.php
+++ b/src/Contracts/ClientFactoryContract.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JustBetter\DynamicsClient\Contracts;
+
+use SaintSystems\OData\ODataClient;
+
+interface ClientFactoryContract
+{
+    public static function make(string $connection): static;
+
+    public function etag(string $etag): static;
+
+    public function fabricate(): ODataClient;
+}

--- a/src/OData/BaseResource.php
+++ b/src/OData/BaseResource.php
@@ -130,6 +130,7 @@ abstract class BaseResource implements Arrayable, ArrayAccess
 
     public function client(string $etag = null): ODataClient
     {
+        /** @var ClientFactoryContract $factory */
         $factory = app(ClientFactoryContract::class, ['connection' => $this->connection]);
 
         if ($etag) {

--- a/src/OData/BaseResource.php
+++ b/src/OData/BaseResource.php
@@ -5,11 +5,11 @@ namespace JustBetter\DynamicsClient\OData;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
-use JustBetter\DynamicsClient\Client\ClientFactory;
 use JustBetter\DynamicsClient\Concerns\CanBeSerialized;
 use JustBetter\DynamicsClient\Concerns\HasCasts;
 use JustBetter\DynamicsClient\Concerns\HasData;
 use JustBetter\DynamicsClient\Concerns\HasKeys;
+use JustBetter\DynamicsClient\Contracts\ClientFactoryContract;
 use JustBetter\DynamicsClient\Exceptions\DynamicsException;
 use JustBetter\DynamicsClient\Query\QueryBuilder;
 use SaintSystems\OData\Entity;
@@ -25,8 +25,6 @@ abstract class BaseResource implements Arrayable, ArrayAccess
     public string $connection;
 
     public string $endpoint;
-
-    protected ?ODataClient $client;
 
     final public function __construct(string $connection = null, string $endpoint = null)
     {
@@ -55,13 +53,6 @@ abstract class BaseResource implements Arrayable, ArrayAccess
     public function setEndpoint(string $endpoint): static
     {
         $this->endpoint = $endpoint;
-
-        return $this;
-    }
-
-    public function setClient(ODataClient $client): static
-    {
-        $this->client = $client;
 
         return $this;
     }
@@ -139,17 +130,13 @@ abstract class BaseResource implements Arrayable, ArrayAccess
 
     public function client(string $etag = null): ODataClient
     {
-        if (!isset($this->client)) {
-            $factory = ClientFactory::make($this->connection);
+        $factory = app(ClientFactoryContract::class, ['connection' => $this->connection]);
 
-            if ($etag) {
-                $factory->etag($etag);
-            }
-
-            $this->client = $factory->fabricate();
+        if ($etag) {
+            $factory->etag($etag);
         }
 
-        return $this->client;
+        return $factory->fabricate();
     }
 
     public function newQuery(): QueryBuilder

--- a/src/OData/BaseResource.php
+++ b/src/OData/BaseResource.php
@@ -26,6 +26,8 @@ abstract class BaseResource implements Arrayable, ArrayAccess
 
     public string $endpoint;
 
+    protected ?ODataClient $client;
+
     final public function __construct(string $connection = null, string $endpoint = null)
     {
         $this->connection ??= $connection ?? config('dynamics.connection');
@@ -53,6 +55,13 @@ abstract class BaseResource implements Arrayable, ArrayAccess
     public function setEndpoint(string $endpoint): static
     {
         $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    public function setClient(ODataClient $client): static
+    {
+        $this->client = $client;
 
         return $this;
     }
@@ -130,13 +139,17 @@ abstract class BaseResource implements Arrayable, ArrayAccess
 
     public function client(string $etag = null): ODataClient
     {
-        $factory = ClientFactory::make($this->connection);
+        if (!isset($this->client)) {
+            $factory = ClientFactory::make($this->connection);
 
-        if ($etag) {
-            $factory->etag($etag);
+            if ($etag) {
+                $factory->etag($etag);
+            }
+
+            $this->client = $factory->fabricate();
         }
 
-        return $factory->fabricate();
+        return $this->client;
     }
 
     public function newQuery(): QueryBuilder

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,9 +23,11 @@ class ServiceProvider extends BaseServiceProvider
         return $this;
     }
 
-    protected function bindResolvers()
+    protected function bindResolvers(): static
     {
         $this->app->bind(ClientFactoryContract::class, ClientFactory::class);
+
+        return $this;
     }
 
     public function boot(): void

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,15 +2,18 @@
 
 namespace JustBetter\DynamicsClient;
 
-use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use JustBetter\DynamicsClient\Client\ClientFactory;
 use JustBetter\DynamicsClient\Commands\TestConnection;
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use JustBetter\DynamicsClient\Contracts\ClientFactoryContract;
 
 class ServiceProvider extends BaseServiceProvider
 {
     public function register(): void
     {
         $this
-            ->registerConfig();
+            ->registerConfig()
+            ->bindResolvers();
     }
 
     protected function registerConfig(): static
@@ -18,6 +21,11 @@ class ServiceProvider extends BaseServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/dynamics.php', 'dynamics');
 
         return $this;
+    }
+
+    protected function bindResolvers()
+    {
+        $this->app->bind(ClientFactoryContract::class, ClientFactory::class);
     }
 
     public function boot(): void


### PR DESCRIPTION
Hey there,

Adding this PR to allow overriding the Resource client on-the-fly. This allow to dynamically set a Client initialized from a custom ClientFactory, for example when working with OAuth application managing multiple tenants.

Usage example :

```php
$client = new ODataClient("http://my.tenant", null, $httpProvider);

$results = Customer::new()
    ->setClient($client)
    ->newQuery()
    ->where('City', '=', 'Alkmaar')
    ->lazy();
```

